### PR TITLE
Remove sharp ignore plugin and .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-sharp_binary_host=https://npmmirror.com/mirrors/sharp
-sharp_libvips_binary_host=https://npmmirror.com/mirrors/sharp-libvips
-sharp_platform=linux
-sharp_arch=x64 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,11 +21,6 @@ const nextConfig = {
         resourceRegExp: /^cloudflare:sockets$/
       })
     );
-    config.plugins.push(
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^sharp$/
-      })
-    );
     return config;
   }
 }


### PR DESCRIPTION
## Summary
- remove IgnorePlugin rule for `sharp`
- delete custom `.npmrc` so Vercel can download official sharp binaries

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e1bdc774832180f68e59179026bf